### PR TITLE
Död länk till Coderdojo.org

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -28,7 +28,7 @@ title: CoderDojos i Sverige
           <% url_list.each_pair do |city, href| %>
             <div>
             <h4><%= city %></h4>
-            <a href="<%= href %>"><%= href %></a>
+            <a href="<%= href %>" target="_blank"><%= href %></a>
           </div>
         <% end %>
         </div>

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -15,7 +15,7 @@ title: CoderDojos i Sverige
   "Stockholm" => "http://coderdojostockholm.se/",
   "Söderköping" => "https://zen.coderdojo.com/dojo/699",
   "Växjö" => "http://vaxjo.coderdojo.se/",
-  "Resten av världen" => "http://zen.coderdojo.org/",
+  "Resten av världen" => "https://zen.coderdojo.com/",
 } %>
 
 <div class="row-fluid">


### PR DESCRIPTION
Länken till coderdojo.org var död, så fixade den. Passade också på att göra så länkar öppnas i ny flik.